### PR TITLE
fix some clippy lints

### DIFF
--- a/bin/galois.rs
+++ b/bin/galois.rs
@@ -31,7 +31,7 @@ fn main() {
 }
 
 fn print_banner() {
-    let banner = r#"
+    const BANNER: &str = r#"
 
                  **       **
    *******     ******     **               **
@@ -44,5 +44,5 @@ fn print_banner() {
       *    *    ****  *   **      ***      **    ** ***
                                                   ****
 "#;
-    println!("{}", banner);
+    println!("{}", BANNER);
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -14,7 +14,7 @@
 
 use crate::config;
 use lazy_static::lazy_static;
-use mysql::*;
+use mysql::Pool;
 use redis::Client;
 
 lazy_static! {

--- a/src/event.rs
+++ b/src/event.rs
@@ -88,7 +88,7 @@ pub enum Inspection {
 fn handle_limit(
     event_id: u64,
     data: &mut Data,
-    symbol: &Symbol,
+    symbol: Symbol,
     price: Decimal,
     amount: Decimal,
     user: u64,
@@ -97,7 +97,7 @@ fn handle_limit(
     time: u64,
     sender: &Sender<Vec<output::Output>>,
 ) -> bool {
-    let orderbook = data.orderbooks.get_mut(symbol);
+    let orderbook = data.orderbooks.get_mut(&symbol);
     let account = data.accounts.get_mut(&user);
     match (orderbook, account) {
         (Some(orderbook), Some(account)) => {
@@ -140,7 +140,7 @@ fn handle_limit(
                 let cr = clearing::clear(
                     &mut data.accounts,
                     event_id,
-                    symbol,
+                    &symbol,
                     orderbook.taker_fee,
                     orderbook.maker_fee,
                     &mr,
@@ -206,7 +206,7 @@ fn handle_event(
     match event {
         Event::Limit(id, symbol, user, order, price, amount, ask_or_bid, time) => {
             let ok = handle_limit(
-                id, data, &symbol, price, amount, user, order, ask_or_bid, time, &sender,
+                id, data, symbol, price, amount, user, order, ask_or_bid, time, sender,
             );
             (id, ok)
         }
@@ -359,7 +359,7 @@ fn handle_event(
             None => (id, false),
         },
         Event::Dump(id, time) => {
-            snapshot::dump(id, time, &data);
+            snapshot::dump(id, time, data);
             // tricky way, return u64::MAX to update nothing
             (u64::MAX, true)
         }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -81,7 +81,7 @@ impl Taker {
         }
     }
 
-    pub fn taker_placed(
+    pub const fn taker_placed(
         user_id: u64,
         order_id: u64,
         price: Decimal,
@@ -98,7 +98,7 @@ impl Taker {
         }
     }
 
-    pub fn cancel(
+    pub const fn cancel(
         user_id: u64,
         order_id: u64,
         price: Decimal,
@@ -126,7 +126,12 @@ pub struct Maker {
 }
 
 impl Maker {
-    pub fn maker_filled(user_id: u64, order_id: u64, price: Decimal, filled: Decimal) -> Self {
+    pub const fn maker_filled(
+        user_id: u64,
+        order_id: u64,
+        price: Decimal,
+        filled: Decimal,
+    ) -> Self {
         Self {
             user_id,
             order_id,
@@ -136,7 +141,12 @@ impl Maker {
         }
     }
 
-    pub fn maker_so_far(user_id: u64, order_id: u64, price: Decimal, filled: Decimal) -> Self {
+    pub const fn maker_so_far(
+        user_id: u64,
+        order_id: u64,
+        price: Decimal,
+        filled: Decimal,
+    ) -> Self {
         Self {
             user_id,
             order_id,

--- a/src/orderbook.rs
+++ b/src/orderbook.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::core::*;
+use crate::core::Symbol;
 use linked_hash_map::LinkedHashMap;
 use rust_decimal::{prelude::Zero, Decimal};
 use serde::{Deserialize, Serialize};
@@ -38,7 +38,7 @@ pub struct Order {
 }
 
 impl Order {
-    pub fn new(id: u64, user: u64, price: Decimal, unfilled: Decimal) -> Self {
+    pub const fn new(id: u64, user: u64, price: Decimal, unfilled: Decimal) -> Self {
         Self {
             id,
             user,
@@ -89,8 +89,8 @@ impl OrderPage {
         })
     }
 
-    pub fn get(&self, order_id: &u64) -> Option<&Order> {
-        self.orders.get(order_id)
+    pub fn get(&self, order_id: u64) -> Option<&Order> {
+        self.orders.get(&order_id)
     }
 }
 
@@ -217,11 +217,11 @@ impl OrderBook {
         let price = self.indices.get(&order_id)?;
         let best_ask = self.get_best_ask()?;
         if *price >= best_ask {
-            self.asks.get(&price).and_then(|page| page.get(&order_id))
+            self.asks.get(price).and_then(|page| page.get(order_id))
         } else {
             let best_bid = self.get_best_bid()?;
             if *price <= best_bid {
-                self.bids.get(&price).and_then(|page| page.get(&order_id))
+                self.bids.get(price).and_then(|page| page.get(order_id))
             } else {
                 None
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -50,6 +50,7 @@ pub struct Message {
 }
 
 impl Message {
+    #[must_use]
     pub fn with_payload(session: u64, req_id: u64, payload: Vec<u8>) -> Self {
         Self {
             session,
@@ -82,13 +83,13 @@ impl Message {
 
 /// header = 0x0316<2bytes payload len><2bytes cheskcum><2bytes flag>
 
-const _MAGIC_N_MASK: u64 = 0x0316000000000000;
-const _PAYLOAD_MASK: u64 = 0x0000ffff00000000;
-const _CHK_SUM_MASK: u64 = 0x00000000ffff0000;
-const _ERR_RSP_MASK: u64 = 0x0000000000000001;
-const _NXT_FRM_MASK: u64 = 0x0000000000000002;
+const _MAGIC_N_MASK: u64 = 0x0316_0000_0000_0000;
+const _PAYLOAD_MASK: u64 = 0x0000_ffff_0000_0000;
+const _CHK_SUM_MASK: u64 = 0x0000_0000_ffff_0000;
+const _ERR_RSP_MASK: u64 = 0x0000_0000_0000_0001;
+const _NXT_FRM_MASK: u64 = 0x0000_0000_0000_0002;
 
-fn check_magic(header: u64) -> bool {
+const fn check_magic(header: u64) -> bool {
     (header & _MAGIC_N_MASK) == _MAGIC_N_MASK
 }
 
@@ -97,11 +98,11 @@ fn get_len(header: u64) -> usize {
 }
 
 #[allow(dead_code)]
-fn get_checksum(header: u64) -> u16 {
+const fn get_checksum(header: u64) -> u16 {
     ((header & _CHK_SUM_MASK) >> 16) as u16
 }
 
-fn has_next_frame(header: u64) -> bool {
+const fn has_next_frame(header: u64) -> bool {
     (header & _NXT_FRM_MASK) == _NXT_FRM_MASK
 }
 
@@ -117,7 +118,7 @@ async fn accept(
 ) -> Result<()> {
     let listener = TcpListener::bind(addr).await?;
     let mut incoming = listener.incoming();
-    let mut session = 0u64;
+    let mut session = 0_u64;
     while let Some(stream) = incoming.next().await {
         if ready.load(Ordering::Relaxed) {
             let stream = stream?;
@@ -186,8 +187,8 @@ async fn read_loop(cmd_acc: Sender<Fusion>, session: u64, stream: Arc<TcpStream>
     let mut stream = &*stream;
     let mut buf = Vec::<u8>::with_capacity(4096);
     loop {
-        let mut header = [0u8; 8];
-        let mut req_id = [0u8; 8];
+        let mut header = [0_u8; 8];
+        let mut req_id = [0_u8; 8];
         if stream.read_exact(&mut header).await.is_err() {
             break;
         }
@@ -199,7 +200,7 @@ async fn read_loop(cmd_acc: Sender<Fusion>, session: u64, stream: Arc<TcpStream>
             break;
         }
         let req_id = u64::from_be_bytes(req_id);
-        let mut tmp = vec![0u8; get_len(header)];
+        let mut tmp = vec![0_u8; get_len(header)];
         if stream.read_exact(&mut tmp).await.is_err() {
             break;
         }


### PR DESCRIPTION
## fixed clippy lints

### fix all argument size should passed by value warnings

```
warning: this argument (8 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
  --> src/output.rs:76:27
   |
76 | fn get_max_record(symbol: &Symbol) -> u64 {
   |                           ^^^^^^^ help: consider passing by value instead: `Symbol`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref
```

### fix all this could be const fn warnings

```
warning: this could be a `const fn`
  --> src/server.rs:96:1
   |
96 | / fn get_len(header: u64) -> usize {
97 | |     ((header & _PAYLOAD_MASK) >> 32) as usize
98 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn
```

### fix all integer type suffix should be separated by an underscore

```
warning: integer type suffix should be separated by an underscore
   --> src/sequence.rs:367:23
    |
367 |     let mut counter = 0usize;
    |                       ^^^^^^ help: add an underscore: `0_usize`
    |
    = note: `-W clippy::unseparated-literal-suffix` implied by `-W clippy::pedantic`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unseparated_literal_suffix
```

## some clippy warnings that not fix

### match bool

```
warning: you seem to be trying to match on a boolean expression
   --> src/matcher.rs:176:20
    |
176 |               return match !makers.is_empty() {
    |  ____________________^
177 | |                 true => Some(Match {
178 | |                     maker: makers,
179 | |                     taker: Taker::taker_filled(user_id, order_id, price, ask_or_bid),
180 | |                 }),
181 | |                 false => None,
182 | |             };
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_bool
help: consider using an `if`/`else` expression
```

### future lint

```
warning: future cannot be sent between threads safely
   --> src/server.rs:118:6
    |
118 | ) -> Result<()> {
    |      ^^^^^^^^^^ future returned by `accept` is not `Send`
    |
    = note: `-W clippy::future-not-send` implied by `-W clippy::nursery`
note: future is not `Send` as this value is used across an await
   --> src/server.rs:122:30
    |
115 |     addr: impl ToSocketAddrs,
    |     ---- has type `impl ToSocketAddrs` which is not `Send`
...
122 |     while let Some(stream) = incoming.next().await {
    |                              ^^^^^^^^^^^^^^^^^^^^^ await occurs here, with `addr` maybe used later
...
130 | }
    | - `addr` is later dropped here
    = note: `impl ToSocketAddrs` doesn't implement `std::marker::Send`
    = note: `impl ToSocketAddrs` doesn't implement `std::marker::Sync`
    = note: `<impl ToSocketAddrs as async_std::net::ToSocketAddrs>::Iter` doesn't implement `std::marker::Send`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#future_not_send
```
